### PR TITLE
Encode a common pattern as the default behavior.

### DIFF
--- a/lib/gen_registry.ex
+++ b/lib/gen_registry.ex
@@ -85,7 +85,19 @@ defmodule GenRegistry do
   """
   @spec lookup_or_start(registry :: GenServer.server(), id :: Types.id(), args :: [any], timeout :: integer) ::
           {:ok, pid} | {:error, any}
-  def lookup_or_start(registry, id, args \\ [], timeout \\ 5_000) do
+  def lookup_or_start(registry, id, args \\ [], timeout \\ 5_000)
+
+  def lookup_or_start(registry, id, args, timeout) when is_atom(registry) do
+    case lookup(registry, id) do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      {:error, :not_found} ->
+        @gen_module.call(registry, {:lookup_or_start, id, args}, timeout)
+    end
+  end
+
+  def lookup_or_start(registry, id, args, timeout) do
     @gen_module.call(registry, {:lookup_or_start, id, args}, timeout)
   end
 

--- a/test/gen_registry_test.exs
+++ b/test/gen_registry_test.exs
@@ -11,8 +11,8 @@ defmodule GenRegistry.Test do
   """
   @spec start_registry(ctx :: Map.t()) :: :ok
   def start_registry(_) do
-    {:ok, _} = start_supervised({GenRegistry, worker_module: ExampleWorker})
-    :ok
+    {:ok, registry} = start_supervised({GenRegistry, worker_module: ExampleWorker})
+    {:ok, registry: registry}
   end
 
   @doc """
@@ -220,6 +220,37 @@ defmodule GenRegistry.Test do
 
       # Assert that the response is the one returned from the call
       assert {:ok, pid} == response
+    end
+
+    test "when given a pid will perform a server-side lookup and start if id is running", ctx do
+      # Start a process so something will be available client-side
+      assert {:ok, pid} = GenRegistry.lookup_or_start(ExampleWorker, :test_id, [:test])
+
+      # Replace the GenRegistry with a Spy
+      assert {:ok, spy} = Spy.replace(ctx.registry)
+
+      # Assert that the spy has seen 0 calls
+      assert {:ok, []} == Spy.calls(spy)
+
+      # Assert that the GenRegistry can lookup the `:test_id` process
+      assert {:ok, pid} == GenRegistry.lookup_or_start(spy, :test_id, [:test])
+
+      # Assert again that the spy has seen 0 calls
+      assert {:ok, [{call, response}]} = Spy.calls(spy)
+    end
+
+    test "when given a pid will perform server-side lookup and start if id is not running", ctx do
+      # Replace the GenRegistry with a Spy
+      assert {:ok, spy} = Spy.replace(ctx.registry)
+
+      # Assert that the spy has seen 0 calls
+      assert {:ok, []} == Spy.calls(spy)
+
+      # Assert that the GenRegistry can lookup the `:test_id` process
+      assert {:ok, pid} = GenRegistry.lookup_or_start(spy, :test_id, [:test])
+
+      # Assert again that the spy has seen 0 calls
+      assert {:ok, [{call, response}]} = Spy.calls(spy)
     end
   end
 

--- a/test/gen_registry_test.exs
+++ b/test/gen_registry_test.exs
@@ -184,6 +184,43 @@ defmodule GenRegistry.Test do
       # Confirm that the registry has 1 process
       assert 1 == GenRegistry.count(ExampleWorker)
     end
+
+    test "when given a local name will perform a client-side lookup" do
+      # Start a process so something will be available client-side
+      assert {:ok, pid} = GenRegistry.lookup_or_start(ExampleWorker, :test_id, [:test])
+
+      # Replace the GenRegistry with a Spy
+      assert {:ok, spy} = Spy.replace(ExampleWorker)
+
+      # Assert that the spy has seen 0 calls
+      assert {:ok, []} == Spy.calls(spy)
+
+      # Assert that the GenRegistry can lookup the `:test_id` process
+      assert {:ok, pid} == GenRegistry.lookup_or_start(ExampleWorker, :test_id, [:test])
+
+      # Assert again that the spy has seen 0 calls
+      assert {:ok, []} == Spy.calls(spy)
+    end
+
+    test "when given a local name will perform a server-side lookup and start if id not found" do
+      # Replace the GenRegistry with a Spy
+      assert {:ok, spy} = Spy.replace(ExampleWorker)
+
+      # Assert that the spy has seen 0 calls
+      assert {:ok, []} == Spy.calls(spy)
+
+      # Assert that the GenRegistry can still perform a lookup_or_start
+      assert {:ok, pid} = GenRegistry.lookup_or_start(ExampleWorker, :test_id, [:test])
+
+      # Assert that the spy saw the call for lookup_or_start
+      assert {:ok, [{call, response}]} = Spy.calls(spy)
+
+      # Assert that the call is what we would expect for a server-side lookup_or_start
+      assert {:lookup_or_start, :test_id, [:test]} == call
+
+      # Assert that the response is the one returned from the call
+      assert {:ok, pid} == response
+    end
   end
 
   describe "stop/2" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -48,6 +48,10 @@ defmodule Spy do
     GenServer.start_link(__MODULE__, original)
   end
 
+  def replace(pid) when is_pid(pid) do
+    start_link(pid)
+  end
+
   def replace(name) do
     case Process.whereis(name) do
       nil ->


### PR DESCRIPTION
It is a common pattern when using GenRegistry to wrap lookup_or_start/4
with a call to lookup/2 first.

This pattern exists because it allows the caller to do a fast ETS
lookup in the client context without having to switch to the server
context when the process is already running.

lookup_or_start/4 accepts a GenServer.server(), in the cases that a
caller uses a pid, the old path will be followed since there's no good
way to go from pid to :ets.tab().  If the caller provides an atom
(local named process) then the atom will be assumed to be the
:ets.tab() and a client-side lookup performed.