### PR TITLE
Adds a start/4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,32 @@ jobs:
             otp-version: 22.3
           - elixir-version: 1.10.4
             otp-version: 23.2
-          - elixir-version: 1.11.3
+          - elixir-version: 1.11.4
             otp-version: 21.3
-          - elixir-version: 1.11.3
+          - elixir-version: 1.11.4
             otp-version: 22.3
-          - elixir-version: 1.11.3
+          - elixir-version: 1.11.4
             otp-version: 23.2
+          - elixir-version: 1.12.3
+            otp-version: 22.3
+          - elixir-version: 1.12.3
+            otp-version: 23.3
+          - elixir-version: 1.12.3
+            otp-version: 24.3
+          - elixir-version: 1.13.4
+            otp-version: 22.3
+          - elixir-version: 1.13.4
+            otp-version: 23.3
+          - elixir-version: 1.13.4
+            otp-version: 24.3
+          - elixir-version: 1.13.4
+            otp-version: 25.1
+          - elixir-version: 1.14.0
+            otp-version: 23.3
+          - elixir-version: 1.14.0
+            otp-version: 24.3
+          - elixir-version: 1.14.0
+            otp-version: 25.1
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir

--- a/lib/behaviour.ex
+++ b/lib/behaviour.ex
@@ -9,10 +9,13 @@ defmodule GenRegistry.Behaviour do
   alias :ets, as: ETS
   alias GenRegistry.Types
 
-  @callback lookup(ETS.tab(), Types.id()) :: {:ok, pid} | {:error, :not_found}
-  @callback lookup_or_start(pid, Types.id(), args :: [term], timeout :: integer) ::
-              {:ok, pid} | {:error, term}
-  @callback stop(pid, Types.id()) :: :ok | {:error, :not_found}
-  @callback count(ETS.tab()) :: integer
-  @callback reduce(ETS.tab(), term, ({Types.id(), pid}, term -> term)) :: term
+  @callback count(ETS.tab()) :: integer()
+  @callback lookup(ETS.tab(), Types.id()) :: {:ok, pid()} | {:error, :not_found}
+  @callback lookup_or_start(GenServer.server(), Types.id(), args :: [any()], timeout :: integer()) ::
+              {:ok, pid()} | {:error, any()}
+  @callback reduce(ETS.tab(), any(), ({Types.id(), pid()}, any() -> any())) :: any()
+  @callback sample(ETS.tab()) :: {Types.id(), pid()} | nil
+  @callback start(GenServer.server(), Types.id(), args :: [any()], timeout :: integer()) :: {:ok, pid()} | {:error, {:already_started, pid()}} | {:error, any()}
+  @callback stop(GenServer.server(), Types.id()) :: :ok | {:error, :not_found}
+  @callback to_list(ETS.tab()) :: [{Types.id(), pid()}]
 end

--- a/test/gen_registry_test.exs
+++ b/test/gen_registry_test.exs
@@ -145,7 +145,7 @@ defmodule GenRegistry.Test do
 
       # Confirm that the running processes are unaffected by the failed start
       for i <- 1..5 do
-        assert {:ok, pid} = GenRegistry.lookup_or_start(ExampleWorker, i)
+        assert {:ok, pid} = GenRegistry.lookup(ExampleWorker, i)
         assert Process.alive?(pid)
       end
     end
@@ -260,6 +260,197 @@ defmodule GenRegistry.Test do
 
       # Assert that the call is what we would expect for a server-side lookup_or_start
       assert {:lookup_or_start, :test_id, [:test]} == call
+
+      # Assert that the response is the one returned from the call
+      assert {:ok, pid} == response
+    end
+  end
+
+  describe "start/4" do
+    setup [:start_registry]
+
+    test "unknown id starts a new process" do
+      assert {:ok, pid} = GenRegistry.start(ExampleWorker, :unknown)
+      assert {:ok, ^pid} = GenRegistry.lookup(ExampleWorker, :unknown)
+    end
+
+    test "known id returns an error" do
+      # Confirm that the registry is empty
+      assert 0 == GenRegistry.count(ExampleWorker)
+
+      # Start a new process
+      assert {:ok, pid} = GenRegistry.start(ExampleWorker, :test_id)
+
+      # Confirm that the registry has 1 process
+      assert 1 == GenRegistry.count(ExampleWorker)
+
+      # Attempting to start the same id will return an error
+      assert {:error, {:already_started, ^pid}} = GenRegistry.start(ExampleWorker, :test_id)
+
+      # Confirm that the registry still only has 1 process
+      assert 1 == GenRegistry.count(ExampleWorker)
+    end
+
+    test "arguments are passed through" do
+      # Start a process with a particular value
+      assert {:ok, first} = GenRegistry.start(ExampleWorker, :a, [:test_value_a])
+
+      # Start another process with a different value
+      assert {:ok, second} = GenRegistry.start(ExampleWorker, :b, [:test_value_b])
+
+      # Assert that the first process has the first value
+      assert :test_value_a == ExampleWorker.get(first)
+
+      # Assert that the second process has the second value
+      assert :test_value_b == ExampleWorker.get(second)
+
+      # Assert that querying through the returned lookup pid returns the correct value, without
+      # having to pass the arguments in again
+      assert {:ok, retrieved} = GenRegistry.lookup_or_start(ExampleWorker, :a)
+      assert :test_value_a = ExampleWorker.get(retrieved)
+    end
+
+    test "invalid arguments return the error and register no process" do
+      assert {:error, :invalid} = GenRegistry.start(ExampleWorker, :test_id, [:invalid])
+    end
+
+    test "invalid start does not effect running processes (failure isolation)" do
+      # Populate the registry with some processes
+      for i <- 1..5 do
+        assert {:ok, _} = GenRegistry.start(ExampleWorker, i)
+      end
+
+      # Confirm that there are 5 processes
+      assert 5 == GenRegistry.count(ExampleWorker)
+
+      # Start a process with invalid arguments
+      assert {:error, :invalid} = GenRegistry.start(ExampleWorker, :test_id, [:invalid])
+
+      # Confirm that there are still 5 processes in the registry
+      assert 5 == GenRegistry.count(ExampleWorker)
+
+      # Confirm that the running processes are unaffected by the failed start
+      for i <- 1..5 do
+        assert {:ok, pid} = GenRegistry.lookup(ExampleWorker, i)
+        assert Process.alive?(pid)
+      end
+    end
+
+    test "id can be reused if the process exits" do
+      # Start a process with a particular value
+      assert {:ok, pid} = GenRegistry.start(ExampleWorker, :test_id, [:original])
+
+      # Confirm that the process is working correctly
+      assert :original == ExampleWorker.get(pid)
+
+      # Confirm that the registry has exactly 1 process
+      assert 1 == GenRegistry.count(ExampleWorker)
+
+      # Confirm that the running process causes an already_started error
+      assert {:error, {:already_started, ^pid}} =
+               GenRegistry.start(ExampleWorker, :test_id, [:duplicate])
+
+      # Confirm that the process is working correctly and returning the original value
+      assert :original == ExampleWorker.get(pid)
+
+      # Stop the process
+      assert :ok = GenRegistry.stop(ExampleWorker, :test_id)
+
+      # Confirm that the process has stopped
+      refute Process.alive?(pid)
+
+      # Confirm that the registry has 0 processes
+      assert 0 == GenRegistry.count(ExampleWorker)
+
+      # Attempt to start up a new process with the same id
+      assert {:ok, new_pid} = GenRegistry.start(ExampleWorker, :test_id, [:updated])
+
+      # Confirm that the process is distinct from the first process
+      assert pid != new_pid
+
+      # Confirm that the process is working correctly
+      assert :updated == ExampleWorker.get(new_pid)
+
+      # Confirm that the registry has 1 process
+      assert 1 == GenRegistry.count(ExampleWorker)
+    end
+
+    test "when given a local name will perform a client-side lookup" do
+      # Start a process so something will be available client-side
+      assert {:ok, pid} = GenRegistry.start(ExampleWorker, :test_id, [:test])
+
+      # Replace the GenRegistry with a Spy
+      assert {:ok, spy} = Spy.replace(ExampleWorker)
+
+      # Assert that the spy has seen 0 calls
+      assert {:ok, []} == Spy.calls(spy)
+
+      # Assert that the GenRegistry performs a client-side lookup the `:test_id` process
+      assert {:error, {:already_started, pid}} ==
+               GenRegistry.start(ExampleWorker, :test_id, [:duplicate])
+
+      # Assert again that the spy has seen 0 calls
+      assert {:ok, []} == Spy.calls(spy)
+    end
+
+    test "when given a local name will perform a server-side start if id not found" do
+      # Replace the GenRegistry with a Spy
+      assert {:ok, spy} = Spy.replace(ExampleWorker)
+
+      # Assert that the spy has seen 0 calls
+      assert {:ok, []} == Spy.calls(spy)
+
+      # Assert that the GenRegistry can still perform a lookup_or_start
+      assert {:ok, pid} = GenRegistry.start(ExampleWorker, :test_id, [:test])
+
+      # Assert that the spy saw the call for lookup_or_start
+      assert {:ok, [{call, response}]} = Spy.calls(spy)
+
+      # Assert that the call is what we would expect for a server-side start
+      assert {:start, :test_id, [:test]} == call
+
+      # Assert that the response is the one returned from the call
+      assert {:ok, pid} == response
+    end
+
+    test "when given a pid will perform a server-side start if id is running", ctx do
+      # Start a process so something will be available client-side
+      assert {:ok, pid} = GenRegistry.start(ExampleWorker, :test_id, [:test])
+
+      # Replace the GenRegistry with a Spy
+      assert {:ok, spy} = Spy.replace(ctx.registry)
+
+      # Assert that the spy has seen 0 calls
+      assert {:ok, []} == Spy.calls(spy)
+
+      # Assert that the GenRegistry can lookup the `:test_id` process
+      assert {:error, {:already_started, pid}} == GenRegistry.start(spy, :test_id, [:duplicate])
+
+      # Assert that the spy saw the call for lookup_or_start
+      assert {:ok, [{call, response}]} = Spy.calls(spy)
+
+      # Assert that the call is what we would expect for a server-side start
+      assert {:start, :test_id, [:duplicate]} == call
+
+      # Assert that the response is the one returned from the call
+      assert {:error, {:already_started, pid}} == response
+    end
+
+    test "when given a pid will perform server-side start if id is not running", ctx do
+      # Replace the GenRegistry with a Spy
+      assert {:ok, spy} = Spy.replace(ctx.registry)
+
+      # Assert that the spy has seen 0 calls
+      assert {:ok, []} == Spy.calls(spy)
+
+      # Assert that the GenRegistry can lookup the `:test_id` process
+      assert {:ok, pid} = GenRegistry.start(spy, :test_id, [:test])
+
+      # Assert that the spy saw the call for lookup_or_start
+      assert {:ok, [{call, response}]} = Spy.calls(spy)
+
+      # Assert that the call is what we would expect for a server-side lookup_or_start
+      assert {:start, :test_id, [:test]} == call
 
       # Assert that the response is the one returned from the call
       assert {:ok, pid} == response
@@ -418,7 +609,6 @@ defmodule GenRegistry.Test do
     end
   end
 
-
   describe "to_list/1" do
     setup [:start_registry]
 
@@ -527,14 +717,21 @@ defmodule GenRegistry.Test do
 
   describe "custom name" do
     test "multiple GenRegistries can be started for the same module with custom names" do
-      {:ok, _} = start_supervised({GenRegistry, worker_module: ExampleWorker, name: ExampleWorker.A})
-      {:ok, _} = start_supervised({GenRegistry, worker_module: ExampleWorker, name: ExampleWorker.B})
+      {:ok, _} =
+        start_supervised({GenRegistry, worker_module: ExampleWorker, name: ExampleWorker.A})
+
+      {:ok, _} =
+        start_supervised({GenRegistry, worker_module: ExampleWorker, name: ExampleWorker.B})
 
       assert {:error, :not_found} = GenRegistry.lookup(ExampleWorker.A, :test_id)
-      assert {:ok, worker_a_pid} = GenRegistry.lookup_or_start(ExampleWorker.A, :test_id, [:test_value_a])
+
+      assert {:ok, worker_a_pid} =
+               GenRegistry.lookup_or_start(ExampleWorker.A, :test_id, [:test_value_a])
 
       assert {:error, :not_found} = GenRegistry.lookup(ExampleWorker.B, :test_id)
-      assert {:ok, worker_b_pid} = GenRegistry.lookup_or_start(ExampleWorker.B, :test_id, [:test_value_b])
+
+      assert {:ok, worker_b_pid} =
+               GenRegistry.lookup_or_start(ExampleWorker.B, :test_id, [:test_value_b])
 
       assert worker_a_pid != worker_b_pid
 

--- a/test/supervisor_test.exs
+++ b/test/supervisor_test.exs
@@ -10,11 +10,11 @@ defmodule Supervisor.Test do
       {:ok, supervisor_pid} = Supervisor.start_link(children, strategy: :one_for_one)
 
       assert Supervisor.count_children(supervisor_pid) == %{
-        active: 1,
-        specs: 1,
-        supervisors: 1,
-        workers: 0
-      }
+               active: 1,
+               specs: 1,
+               supervisors: 1,
+               workers: 0
+             }
 
       assert [{ExampleWorker, _, :supervisor, _}] = Supervisor.which_children(supervisor_pid)
 
@@ -24,17 +24,17 @@ defmodule Supervisor.Test do
     test "can customize the name and run multiple registries for the same module" do
       children = [
         GenRegistry.Spec.child_spec(ExampleWorker, name: ExampleWorker.A),
-        GenRegistry.Spec.child_spec(ExampleWorker, name: ExampleWorker.B),
+        GenRegistry.Spec.child_spec(ExampleWorker, name: ExampleWorker.B)
       ]
 
       {:ok, supervisor_pid} = Supervisor.start_link(children, strategy: :one_for_one)
 
       assert Supervisor.count_children(supervisor_pid) == %{
-        active: 2,
-        specs: 2,
-        supervisors: 2,
-        workers: 0
-      }
+               active: 2,
+               specs: 2,
+               supervisors: 2,
+               workers: 0
+             }
 
       children = Supervisor.which_children(supervisor_pid)
 
@@ -74,11 +74,11 @@ defmodule Supervisor.Test do
       {:ok, supervisor_pid} = Supervisor.start_link(children, strategy: :one_for_one)
 
       assert Supervisor.count_children(supervisor_pid) == %{
-        active: 1,
-        specs: 1,
-        supervisors: 1,
-        workers: 0
-      }
+               active: 1,
+               specs: 1,
+               supervisors: 1,
+               workers: 0
+             }
 
       assert [{ExampleWorker, _, :supervisor, _}] = Supervisor.which_children(supervisor_pid)
 
@@ -88,17 +88,17 @@ defmodule Supervisor.Test do
     test "can customize the name and run multiple registries for the same module" do
       children = [
         {GenRegistry, worker_module: ExampleWorker, name: ExampleWorker.A},
-        {GenRegistry, worker_module: ExampleWorker, name: ExampleWorker.B},
+        {GenRegistry, worker_module: ExampleWorker, name: ExampleWorker.B}
       ]
 
       {:ok, supervisor_pid} = Supervisor.start_link(children, strategy: :one_for_one)
 
       assert Supervisor.count_children(supervisor_pid) == %{
-        active: 2,
-        specs: 2,
-        supervisors: 2,
-        workers: 0
-      }
+               active: 2,
+               specs: 2,
+               supervisors: 2,
+               workers: 0
+             }
 
       children = Supervisor.which_children(supervisor_pid)
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -62,13 +62,12 @@ defmodule Spy do
   end
 
   def init(original) do
-    state =
-      %{
-        original: original,
-        calls: [],
-        casts: [],
-        messages: []
-      }
+    state = %{
+      original: original,
+      calls: [],
+      casts: [],
+      messages: []
+    }
 
     {:ok, state}
   end


### PR DESCRIPTION
start/4 allows the caller to know whether or not they started the worker process.  lookup_or_start/4 is transparent about whether the worker process was started fresh or already existed. Some use cases require that the caller be able to tell whether or not they started the worker process.

start/4 will error if the worker process already exists with `{:error, {:already_started, pid}}` similar to how a Supervisor behaves when a child is already running.