### PR TITLE
Fix for Elixir 1.18, add parentheses to `module_info` call

### DIFF
--- a/lib/gen_registry.ex
+++ b/lib/gen_registry.ex
@@ -204,7 +204,7 @@ defmodule GenRegistry do
     Process.flag(:trap_exit, true)
 
     worker_type =
-      case worker_module.module_info[:attributes][:behaviour] do
+      case worker_module.module_info()[:attributes][:behaviour] do
         [:supervisor] -> :supervisor
         _ -> :worker
       end


### PR DESCRIPTION
On Elixir 1.18, I was running into the following warning, caused by a function call in gen_registry that didn't have parentheses.

```
warning: using map.field notation (without parentheses) to invoke function Gateway.Gen.UserSession.module_info() is deprecated, you must add parentheses instead: remote.function()
  (gen_registry 1.3.0) lib/gen_registry.ex:207: GenRegistry.init/1
  (stdlib 6.0.1) gen_server.erl:2057: :gen_server.init_it/2
  (stdlib 6.0.1) gen_server.erl:2012: :gen_server.init_it/6
  (stdlib 6.0.1) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```